### PR TITLE
There is a typo in memento_dbwriter.pl, line 141: it is expected to be $slaves instead of $masters

### DIFF
--- a/writer/memento_dbwriter.pl
+++ b/writer/memento_dbwriter.pl
@@ -138,7 +138,7 @@ getdb();
         ('SELECT sourceid, block_num, irreversible FROM SYNC WHERE is_master=0');
     $sth->execute();
     my $slaves = $sth->fetchall_arrayref();
-    if( scalar(@{$masters}) > 1 )
+    if( scalar(@{$slaves}) > 1 )
     {
         die("SYNC table contains more than one slave\n");
     }


### PR DESCRIPTION
There is a typo in memento_dbwriter.pl, line 141: it is expected to be $slaves instead of $masters